### PR TITLE
Fix error where ReadString returns io.EOF.

### DIFF
--- a/main.go
+++ b/main.go
@@ -436,6 +436,9 @@ func readTestResult(r *bufio.Reader, path string) {
 	for {
 		line, err := r.ReadString('\n')
 		os.Stdout.WriteString(line)
+		if err == io.EOF {
+			break
+		}
 		if err != nil {
 			log.Fatalf("reading test output for %s: %v", path, err)
 		}


### PR DESCRIPTION
This can happen when the cache is cleared and the last package to test doesn't
have tests.

---

I somewhat recall that you had stated that this was a failed experiment but I failed to find any written explanation so I don't know if you accept changes to this repository.

I am experiencing this on https://periph.io/x/periph, as the last package "videocore" doesn't have test yet. There seem to be some amount of non-determinism in the reproduction but it's very frequent on go1.8, reproduced on Windows 10, Raspberry PI 3 and a high end z620.

Thanks